### PR TITLE
Add delayed triggering support for companion sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ Currently, these are the implemented virtual accessories:
     - **Plain old switches.** What it says on the label.
     - **Normally on/off switches.** The default state of the switch can be set to "on" or "off". This is also the default state when Homebridge restarts. If you pair it with a timer, the switch will revert back to the default state when the timer expires.
     - **Stateful switches.** The state of the switch persists across restarts of Homebridge. This includes timed switches.
-    - **Switches with companion sensors.** The switch will trigger a companion sensor when it changes state, generating a HomeKit-native notification in the Home app. Selecting a critical sensor type will allow notifications to bypass Focuses like "Do Not Disturb". This is just the easier way of implementing a switch triggered sensor.
+    - **Switches with companion sensors.** The switch will trigger a companion sensor when it changes state, generating a HomeKit-native notification in the Home app. Supports optional delay configuration where only the "triggered" state is delayed, while returning to "normal" is immediate. Selecting a critical sensor type will allow notifications to bypass Focuses like "Do Not Disturb". This is just the easier way of implementing a switch triggered sensor.
     - **Dimmer switches.** To create a dimmer switch use a virtual lightbulb.
     - **Timed switches.** This is a way to introduce timers into HomeKit. The switch will revert back to its default state when the timer expires. If the switch is stateful, the timer will be restored after a restart of Homebridge. While care is taken to restore the timer with the appropriate time correction, **absolute accuracy is not guaranteed and should not be expected**. The accuracy of the restored timer will be affected, among other things, by the hardware and software Homebridge is running on, the number of plugins installed, the order with which the plugins are restored, etc.
 -   **Sensor.** Allows you to create different types of virtual sensors. If Activity Notifications are enabled in the Home app, sensors will generate notifications when their state changes in response to a detected event. Some types of notifications, classified as `critical` by Homekit, are allowed to bypass Focuses like `Do Not Disturb` and some are allowed to appear in CarPlay. Sensors can be activated by different triggers. Currently, the available triggers are:
     - **Host Ping trigger.** Actvates the sensor after a configurable number of failed attempts to ping a network host. The sensor resets when ping is successful.
     - **Cron trigger.** Activates the sensor when the time and date match the schedule deascribed by a cron expression. The sensor resets after a brief delay.
     - **Sun Events trigger.** Activates the sensor when the selected event happens: sunrise, sunset, and golden hour (for the photographers among us). The sensor resets after a brief delay.
-    - **Switch trigger.** To create a switch triggered sensor, create a virtual switch accessory with a companion sensor. This is just the easier way of implementing a switch triggered sensor. A future version may provide the ability to create this pairing as a sensor with a switch trigger.
+    - **Switch trigger.** To create a switch triggered sensor, create a virtual switch accessory with a companion sensor. Supports optional delay configuration for triggering. This is just the easier way of implementing a switch triggered sensor. A future version may provide the ability to create this pairing as a sensor with a switch trigger.
     - **Webhook trigger.** Triggers the sensor via a [webhook call](#webhook-service-configuration). To reset the sensor, trigger it via another web call.
  
 - **Timer.** To create a timer, create a timed switch.
@@ -717,6 +717,45 @@ These are example configurations of the virtual accessories and provided for ref
     "platform": "VirtualAccessoriesForHomebridge"
 }
 ```
+
+#### Companion sensor with delayed triggering
+
+You can configure a delay before the companion sensor triggers when the switch moves away from its default state. The sensor will immediately return to normal when the switch returns to its default state, cancelling any pending delayed trigger.
+
+```json
+{
+    "name": "Virtual Accessories Platform",
+    "devices": [
+        {
+            "accessoryID": "1234567",
+            "accessoryName": "My Switch",
+            "accessoryType": "switch",
+            "accessoryIsStateful": false,
+            "switch": {
+                "defaultState": "off",
+                "hasCompanionSensor": true
+            },
+            "companionSensor": {
+                "name": "My Delayed Motion Sensor",
+                "type": "motion",
+                "delay": {
+                    "days": 0,
+                    "hours": 0,
+                    "minutes": 2,
+                    "seconds": 30
+                }
+            }
+        }
+    ],
+    "platform": "VirtualAccessoriesForHomebridge"
+}
+```
+
+**Delay behavior:**
+- **Triggered state**: Only delayed when moving away from default state (e.g., switch OFF→ON if default is OFF)
+- **Normal state**: Immediate when returning to default state, cancels any pending delayed trigger
+- **Maximum delay**: 7 days
+- **No delay configured**: Sensor triggers immediately (preserves existing behavior)
 
 ### Sensor with ping trigger
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -748,7 +748,7 @@
                 },
                 "hasCompanionSensor": {
                   "title": "Has a Companion Sensor",
-                  "description": "Switch triggers a sensor when its state changes",
+                  "description": "Switch triggers a sensor when its state changes. Supports optional delay for triggered state.",
                   "type": "boolean"
                 },
                 "muteLogging" : {
@@ -1054,6 +1054,35 @@
                     { "title": "Carbon Dioxide (critical)", "enum": ["carbonDioxide"] },
                     { "title": "Carbon Monoxide (critical)", "enum": ["carbonMonoxide"] },
                     { "title": "Smoke (critical)", "enum": ["smoke"] }
+                  ]
+                },
+                "delay": {
+                  "title": "Trigger Delay",
+                  "description": "Time to wait before triggering the sensor (7 days max)",
+                  "type": "object",
+                  "properties": {
+                    "days": { "$ref": "#/$defs/duration/properties/days" },
+                    "hours": {
+                      "$ref": "#/$defs/duration/properties/hours",
+                      "condition": {
+                        "functionBody": "return model.devices[arrayIndices].companionSensor && model.devices[arrayIndices].companionSensor.delay && model.devices[arrayIndices].companionSensor.delay.days < 7;"
+                      }
+                    },
+                    "minutes": {
+                      "$ref": "#/$defs/duration/properties/minutes",
+                      "condition": {
+                        "functionBody": "return model.devices[arrayIndices].companionSensor && model.devices[arrayIndices].companionSensor.delay && model.devices[arrayIndices].companionSensor.delay.days < 7;"
+                      }
+                    },
+                    "seconds": {
+                      "$ref": "#/$defs/duration/properties/seconds",
+                      "condition": {
+                        "functionBody": "return model.devices[arrayIndices].companionSensor && model.devices[arrayIndices].companionSensor.delay && model.devices[arrayIndices].companionSensor.delay.days < 7;"
+                      }
+                    }
+                  },
+                  "allOf": [
+                    { "$ref": "#/$defs/requireHoursMinutesSeconds" }
                   ]
                 }
               },

--- a/src/accessories/virtualAccessorySwitch.ts
+++ b/src/accessories/virtualAccessorySwitch.ts
@@ -134,6 +134,11 @@ export class Switch extends Accessory {
       }
     }
 
+    // Cancel any pending companion sensor delays when switch returns to default state
+    if (this.accessoryConfiguration.switch.hasCompanionSensor && this.states.SwitchState === this.defaultState) {
+      this.companionSensor!.cancelDelayedTrigger();
+    }
+
     this.storeState();
 
     this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting State: ${Switch.getStateName(this.states.SwitchState)}`, this.muteLogging);

--- a/src/configuration/configurationCompanionSensor.ts
+++ b/src/configuration/configurationCompanionSensor.ts
@@ -1,8 +1,11 @@
 /* eslint-disable curly */
 
 import { Validatable } from './validatable.js';
+import { DurationConfiguration } from './configurationDuration.js';
 
 import { Utils } from '../utils/utils.js';
+
+import { Type } from 'typeserializer';
 
 /**
  * 
@@ -10,6 +13,8 @@ import { Utils } from '../utils/utils.js';
 export class CompanionSensorConfiguration implements Validatable {
   name!: string;
   type!: string;
+  @Type(DurationConfiguration)
+    delay?: DurationConfiguration;
 
   private errorFields: string[] = [];
 
@@ -24,12 +29,24 @@ export class CompanionSensorConfiguration implements Validatable {
       Utils.required(this.type)
     );
 
+    let isValidDelay: boolean = true;
+    let delayErrorFields: string[] = [];
+    if (this.delay !== undefined) {
+      [isValidDelay, delayErrorFields] = this.delay.isValid(this.fieldNames.delay!);
+    }
+
     if (!isValidName) this.errorFields.push(prefix + '.' + this.fieldNames.name);
     if (!isValidType) this.errorFields.push(prefix + '.' + this.fieldNames.type);
+    if (!isValidDelay) {
+      delayErrorFields.forEach( (errorField) => {
+        this.errorFields.push(prefix + '.' + errorField);
+      });
+    }
 
     return [
       (isValidName &&
-        isValidType),
+        isValidType &&
+        isValidDelay),
       this.errorFields,
     ];
   }

--- a/src/sensors/companions/companionSensors.ts
+++ b/src/sensors/companions/companionSensors.ts
@@ -4,6 +4,7 @@ import { PlatformAccessory, Service, WithUUID } from 'homebridge';
 
 import { VirtualAccessoriesPlatform } from '../../platform.js';
 import { AccessoryConfiguration } from '../../configuration/configurationAccessory.js';
+import { DurationConfiguration } from '../../configuration/configurationDuration.js';
 
 import { Sensor } from '../sensor.js';
 import { SensorType } from '../../configuration/schema.js';
@@ -20,6 +21,7 @@ import { SmokeSensor } from '../virtualSensorSmoke.js';
 
 export interface TriggerableCompanionSensor {
   triggerCompanionSensorState(sensorState: number, accessory: Accessory, isLoggingDisabled: boolean): void;
+  cancelDelayedTrigger(): void;
 }
 
 export class CompanionSensor {
@@ -72,6 +74,7 @@ function Companion<T extends abstract new (...args: any[]) => Sensor>(
   abstract class CompanionSensor extends SensorInstance implements TriggerableCompanionSensor {
 
     private uuidPostfix: string = '-sensor';
+    private delayedTriggerTimer?: NodeJS.Timeout;
 
     companionConstructor(companionSensorName: string): void {
       // Replace the Sensor Service
@@ -97,12 +100,84 @@ function Companion<T extends abstract new (...args: any[]) => Sensor>(
         throw new AccessoryNotAllowedError(`Switch ${accessory.accessoryConfiguration.accessoryName} is not allowed to trigger this sensor`);
       }
 
+      // Cancel any existing delayed trigger
+      if (this.delayedTriggerTimer) {
+        clearTimeout(this.delayedTriggerTimer);
+        this.delayedTriggerTimer = undefined;
+      }
+
+      // NORMAL state changes are immediate, only TRIGGERED state can be delayed
+      if (sensorState === Sensor.NORMAL) {
+        this.applySensorState(sensorState, isLoggingDisabled);
+        return;
+      }
+
+      // Only delay TRIGGERED state if delay is configured
+      const delay = this.accessoryConfiguration.companionSensor?.delay;
+      if (delay && sensorState === Sensor.TRIGGERED) {
+        const delayInSeconds = delay.toSeconds();
+        if (delayInSeconds > 0) {
+          const delayDescription = this.formatDelayDescription(delay);
+          this.log.info(`[${this.accessoryConfiguration.accessoryName}] Sensor will trigger in ${delayDescription}`, isLoggingDisabled);
+          
+          this.delayedTriggerTimer = setTimeout(() => {
+            this.applySensorState(sensorState, isLoggingDisabled);
+            this.delayedTriggerTimer = undefined;
+          }, delayInSeconds * 1000);
+          return;
+        }
+      }
+      
+      // Immediate trigger for TRIGGERED state without delay or if delay is 0
+      this.applySensorState(sensorState, isLoggingDisabled);
+    }
+
+    private applySensorState(sensorState: number, isLoggingDisabled: boolean) {
       this.states.SensorState = sensorState;
 
       this.service!.updateCharacteristic(this.eventDetected, (this.states.SensorState));
 
       // eslint-disable-next-line max-len
       this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Sensor Current State: ${Sensor.getStateName(this.states.SensorState)}`, isLoggingDisabled);
+    }
+
+    private formatDelayDescription(delay: DurationConfiguration): string {
+      const parts: string[] = [];
+      
+      if (delay.days > 0) {
+        parts.push(`${delay.days} day${delay.days !== 1 ? 's' : ''}`);
+      }
+      if (delay.hours > 0) {
+        parts.push(`${delay.hours} hour${delay.hours !== 1 ? 's' : ''}`);
+      }
+      if (delay.minutes > 0) {
+        parts.push(`${delay.minutes} minute${delay.minutes !== 1 ? 's' : ''}`);
+      }
+      if (delay.seconds > 0) {
+        parts.push(`${delay.seconds} second${delay.seconds !== 1 ? 's' : ''}`);
+      }
+      
+      if (parts.length === 0) {
+        return '0 seconds';
+      }
+      
+      if (parts.length === 1) {
+        return parts[0];
+      }
+      
+      if (parts.length === 2) {
+        return parts.join(' and ');
+      }
+      
+      return parts.slice(0, -1).join(', ') + ', and ' + parts[parts.length - 1];
+    }
+
+    cancelDelayedTrigger(): void {
+      if (this.delayedTriggerTimer) {
+        clearTimeout(this.delayedTriggerTimer);
+        this.delayedTriggerTimer = undefined;
+        this.log.info(`[${this.accessoryConfiguration.accessoryName}] Companion sensor delayed TRIGGERED state cancelled`);
+      }
     }
   };
   return CompanionSensor;


### PR DESCRIPTION
- Add optional delay configuration to companion sensors using days/hours/minutes/seconds structure
- Only triggered state is delayed, normal state changes are immediate
- Normal state cancels any pending delayed trigger
- Delayed triggers are cancelled when switch returns to default state
- Backward compatible - existing configurations continue to work unchanged
- Add configuration UI with duration fields matching reset timer pattern
- Update documentation with examples and behavior explanation