### PR TITLE
attempt to fix zombie processes

### DIFF
--- a/src/accessories/accessory.ts
+++ b/src/accessories/accessory.ts
@@ -124,6 +124,14 @@ export abstract class Accessory {
     }
   }
 
+  /**
+   * Cleanup accessory resources (timers, intervals)
+   * Override in subclasses to clean up specific resources
+   */
+  cleanup(): void {
+    this.log.debug(`[${this.accessoryName}] Accessory cleanup completed`);
+  }
+
   // Store device state if stateful
   protected storeState() {
     if (this.accessoryConfiguration.accessoryIsStateful) {

--- a/src/accessories/openingAccessory.ts
+++ b/src/accessories/openingAccessory.ts
@@ -212,4 +212,9 @@ export abstract class OpeningAccessory extends Accessory {
 
     return stateName;
   }
+
+  cleanup(): void {
+    this.transitionTimer.stop();
+    super.cleanup();
+  }
 }

--- a/src/accessories/virtualAccessoryFilterMaintenance.ts
+++ b/src/accessories/virtualAccessoryFilterMaintenance.ts
@@ -187,4 +187,11 @@ export class FilterMaintenance extends Accessory {
 
     this.log.info(`[${this.accessoryConfiguration.accessoryName}] Filter lifetime expired`);
   }
+
+  cleanup(): void {
+    if (this.lifespanTimer !== undefined) {
+      this.lifespanTimer.stop();
+    }
+    super.cleanup();
+  }
 }

--- a/src/accessories/virtualAccessoryGarageDoor.ts
+++ b/src/accessories/virtualAccessoryGarageDoor.ts
@@ -185,6 +185,11 @@ export class GarageDoor extends Accessory implements UpdatableObstruction {
     return GarageDoor.ACCESSORY_TYPE_NAME;
   }
 
+  cleanup(): void {
+    this.transitionTimer.stop();
+    super.cleanup();
+  }
+
   static getStateName(state: number): string {
     let stateName: string;
 

--- a/src/accessories/virtualAccessoryLock.ts
+++ b/src/accessories/virtualAccessoryLock.ts
@@ -340,6 +340,14 @@ export class Lock extends Accessory {
     return stateName;
   }
 
+  cleanup(): void {
+    if (this.securityTimerId !== undefined) {
+      clearTimeout(this.securityTimerId);
+      this.securityTimerId = undefined;
+    }
+    super.cleanup();
+  }
+
   private startAutoSecurityTimeout(): void {
     if (this.states.LockTargetState !== this.defaultState && this.states.LockManagementAutoSecurityTimeout > 0) {
       const securityTimeoutMillis: number = this.states.LockManagementAutoSecurityTimeout * 1000;

--- a/src/accessories/virtualAccessorySwitch.ts
+++ b/src/accessories/virtualAccessorySwitch.ts
@@ -260,4 +260,11 @@ export class Switch extends Accessory {
   private onTimerExpired(): void {
     this.service!.setCharacteristic(this.platform.Characteristic.On, this.defaultState);
   }
+
+  cleanup(): void {
+    if (this.resetTimer !== undefined) {
+      this.resetTimer.stop();
+    }
+    super.cleanup();
+  }
 }

--- a/src/accessories/virtualAccessoryValve.ts
+++ b/src/accessories/virtualAccessoryValve.ts
@@ -247,4 +247,11 @@ export class Valve extends Accessory {
 
     return eventName;
   }
+
+  cleanup(): void {
+    if (this.durationTimer !== undefined) {
+      this.durationTimer.stop();
+    }
+    super.cleanup();
+  }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -36,6 +36,9 @@ export class VirtualAccessoriesPlatform implements DynamicPlatformPlugin {
   // this is used to track restored cached accessories
   public readonly cachedAccessories: PlatformAccessory[] = [];
 
+  // Track virtual accessories for cleanup
+  private readonly virtualAccessories: Map<string, Accessory> = new Map<string, Accessory>();
+
   public version: string = packageInfo.version;
 
   constructor(
@@ -95,6 +98,12 @@ export class VirtualAccessoriesPlatform implements DynamicPlatformPlugin {
 
     this.api.on(APIEvent.SHUTDOWN, () => {
       log.debug('Executing shutdown callback');
+
+      for (const [, accessory] of this.virtualAccessories) {
+        accessory.cleanup();
+      }
+      this.virtualAccessories.clear();
+
       this.sensorUpdateServer?.stop();
     });
   }
@@ -166,6 +175,7 @@ export class VirtualAccessoriesPlatform implements DynamicPlatformPlugin {
           this.log.debug(`Updating cache: ${accessoryConfiguration.accessoryName}`);
 
           virtualAccessories.push(virtualAccessory);
+          this.virtualAccessories.set(uuid, virtualAccessory);
         }
         else {
           this.log.error(`Error restoring existing accessory: ${accessoryConfiguration.accessoryName}`);
@@ -199,11 +209,13 @@ export class VirtualAccessoriesPlatform implements DynamicPlatformPlugin {
         else if (virtualAccessory.isExternalAccessory()) {
           this.log.info(`Publishing new external accessory: ${accessoryConfiguration.accessoryName}`);
           this.api.publishExternalAccessories(PLUGIN_NAME, [accessory]);
+          this.virtualAccessories.set(uuid, virtualAccessory);
         }
         else {
           // link the accessory to your platform
           this.log.info(`Publishing new accessory: ${accessoryConfiguration.accessoryName}`);
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+          this.virtualAccessories.set(uuid, virtualAccessory);
 
           virtualAccessories.push(virtualAccessory);
         }
@@ -222,6 +234,11 @@ export class VirtualAccessoriesPlatform implements DynamicPlatformPlugin {
         this.log.info(`Removing deleted accessory: ${cachedAccessory.displayName}`);
 
         // Unregister the accessory from the platform
+        const virtualAccessory = this.virtualAccessories.get(cachedAccessory.UUID);
+        if (virtualAccessory !== undefined) {
+          virtualAccessory.cleanup();
+          this.virtualAccessories.delete(cachedAccessory.UUID);
+        }
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [cachedAccessory]);
 
         // Delete any stateful info, if it exists
@@ -234,7 +251,7 @@ export class VirtualAccessoriesPlatform implements DynamicPlatformPlugin {
             else {
               this.log.debug(`Deleted stateful storage for: ${cachedAccessory.displayName}`);
             }
-          }); 
+          });
         }
       }
     }

--- a/src/sensors/binarySensor.ts
+++ b/src/sensors/binarySensor.ts
@@ -120,4 +120,10 @@ export abstract class BinarySensor extends Accessory {
       this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Sensor Current State: ${BinarySensor.getStateName(this.states.SensorState)}`, isLoggingDisabled);
     }
   }
+
+  cleanup(): void {
+    if (this.trigger !== undefined) {
+      this.trigger.cleanup();
+    }
+  }
 }

--- a/src/sensors/triggers/trigger.ts
+++ b/src/sensors/triggers/trigger.ts
@@ -25,4 +25,10 @@ export abstract class Trigger {
 
     this.log = this.sensor.platform.log;
   }
+
+  /**
+   * Cleanup resources (timers, intervals, cron jobs)
+   * Override in subclasses to clean up specific resources
+   */
+  cleanup(): void {}
 }

--- a/src/sensors/triggers/triggerCron.ts
+++ b/src/sensors/triggers/triggerCron.ts
@@ -12,7 +12,7 @@ import '@js-joda/timezone';
  */
 export class CronTrigger extends Trigger {
 
-  private cronJob!: Cron;
+  private cronJob?: Cron;
 
   constructor(
     sensor: BinarySensor,
@@ -80,13 +80,21 @@ export class CronTrigger extends Trigger {
         await Utils.delay(resetDelayMillis);
         sensor.triggerSensorState(BinarySensor.NORMAL, this, triggerConfig.disableTriggerEventLogging);
 
-        if (!this.cronJob.nextRun()) {
+        if (this.cronJob && !this.cronJob.nextRun()) {
           this.log.info(`[${this.sensorConfig.accessoryName}] Stopping cron job`);
         }
       }),
     );
 
     this.displayNextRun(this.cronJob);
+  }
+
+  cleanup(): void {
+    if (this.cronJob !== undefined) {
+      this.cronJob.stop();
+      this.cronJob = undefined;
+      this.log.debug(`[${this.sensorConfig.accessoryName}] Cron trigger cleanup completed`);
+    }
   }
 
   /**

--- a/src/sensors/triggers/triggerPing.ts
+++ b/src/sensors/triggers/triggerPing.ts
@@ -33,6 +33,7 @@ export class PingTrigger extends Trigger {
   private IPv6: number = 6;
 
   private failureCount = new Counter(0);
+  private pingIntervalId: ReturnType<typeof setInterval> | undefined;
 
   constructor(
     sensor: BinarySensor,
@@ -78,13 +79,25 @@ export class PingTrigger extends Trigger {
     const pingTimeoutMillis = 10 * 1000;            // trigger.pingTimeout: 10 seconds
     const intervalBetweenPingsMillis = 60 * 1000;   // trigger.intervalBetweenPings: 60 seconds
 
-    setInterval(
+    this.pingIntervalId = setInterval(
       this.ping, intervalBetweenPingsMillis,
       this,
       triggerConfig,
       protocol,
       pingTimeoutMillis,
     );
+
+    if (this.pingIntervalId) {
+      this.pingIntervalId.unref();
+    }
+  }
+
+  cleanup(): void {
+    if (this.pingIntervalId !== undefined) {
+      clearInterval(this.pingIntervalId);
+      this.pingIntervalId = undefined;
+      this.log.debug(`[${this.sensorConfig.accessoryName}] Ping trigger cleanup completed`);
+    }
   }
 
   /**

--- a/src/sensors/triggers/triggerSunEvents.ts
+++ b/src/sensors/triggers/triggerSunEvents.ts
@@ -16,8 +16,8 @@ export class SunEventsTrigger extends Trigger {
   private SunTimesURL = (latitude: string, longitude: string, timezone: string, date: string) =>
     `https://api.sunrisesunset.io/json?time_format=24&lat=${latitude}&lng=${longitude}&timezone=${timezone}&date=${date}`;
 
-  private triggerCronJob!: Cron;
-  private dataCronJob!: Cron;
+  private triggerCronJob?: Cron;
+  private dataCronJob?: Cron;
 
   private timezone: string | undefined;
 
@@ -54,11 +54,15 @@ export class SunEventsTrigger extends Trigger {
 
         this.setupSunEvent(triggerConfig, timezone, sensor);
 
-        this.displayNextRun(this.dataCronJob);
+        if (this.dataCronJob) {
+          this.displayNextRun(this.dataCronJob);
+        }
       }),
     );
 
-    this.displayNextRun(this.dataCronJob);
+    if (this.dataCronJob) {
+      this.displayNextRun(this.dataCronJob);
+    }
   }
 
   private displayNextRun(
@@ -225,6 +229,18 @@ export class SunEventsTrigger extends Trigger {
     );
 
     this.displayNextRun(this.triggerCronJob);
+  }
+
+  cleanup(): void {
+    if (this.triggerCronJob !== undefined) {
+      this.triggerCronJob.stop();
+      this.triggerCronJob = undefined;
+    }
+    if (this.dataCronJob !== undefined) {
+      this.dataCronJob.stop();
+      this.dataCronJob = undefined;
+    }
+    this.log.debug(`[${this.sensorConfig.accessoryName}] SunEvents trigger cleanup completed`);
   }
 
   private delay(millis: number) {

--- a/src/utils/timer.ts
+++ b/src/utils/timer.ts
@@ -108,6 +108,10 @@ export class Timer {
         }
       }, this.updateIntervalMillis);
 
+      if (this.id) {
+        this.id.unref();
+      }
+
       this.startTime = Utils.now();
       this.isRunning = true;
     }


### PR DESCRIPTION
With the flurry of recent updates, I noticed there were a few zombie homebridge-virtual-accessories processes in  one of my HB docker containers.

I only use the container for pings and a couple of switches so I poked at the likely suspects: timers and intervals.

I added an explicit cleanup method and tracked timers and intervals in their respective objects, and call cleanup on shutdown/removal.
