### PR TITLE
Add support for virtual Slats and tilting blinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You do not have to volunteer to translate it, but hopefully will provide feedbac
     - [Lock](#lock)
     - [Microphone](#microphone)
     - [Security System](#security-system)
+    - [Slats](#slats)
     - [Speaker](#speaker)
     - [Television](#television)
     - [Valve](#valve)
@@ -123,11 +124,12 @@ Currently, these are the implemented virtual accessories:
 -   **Lock.** Allows you to create a virtual lock. Generates an Apple Home notification when the accessory's state changes. This will also create a HomeKey card in the Wallet app. This card is non-functional as it requires some piece of hardware to complete the loop. Also see the [note below](#issues-with-homekit) regarding issues with HomeKey.
 -   **Microphone.** Allows you to create a virtual microphone.
 -   **Security System.** Allows you to create a virtual security system. Generates am Apple Home notification when the accessory's state changes. The Security System can be put in a triggered state via a [webhook call](#webhook-service-configuration). A [webhook endpoint](#webhook-service-configuration) is also available for a panic alarm.
+-   **Slats.** Allows you to create virtual slats.
 -   **Speaker.** Allows you to create a virtual speaker.
 -   **Television.** Allows you to create a virtual television.
 -   **Valve.** Allows you to create different types of virtual valves: generic, irrigation, shower head, or water faucet.
 -   **Window.** Allows you to create a virtual window.
--   **Window Covering.** Allows you to create virtual blinds and shades.
+-   **Window Covering.** Allows you to create virtual blinds and shades. Supports tilt angle.
 -   **Switch.** Allows you to create a number of different types of virtual switches.
     - **Plain old switches.** What it says on the label.
     - **Normally on/off switches.** The default state of the switch can be set to "on" or "off". This is also the default state when Homebridge restarts. If you pair it with a timer, the switch will revert back to the default state when the timer expires.
@@ -556,6 +558,29 @@ These are example configurations of the virtual accessories and provided for ref
     "platform": "VirtualAccessoriesForHomebridge"
 ```
 
+### Slats
+
+```json
+{
+    "name": "Virtual Accessories Platform",
+    "devices": [
+        {
+            "accessoryID": "1234567",
+            "accessoryName": "My Slats",
+            "accessoryType": "slats",
+            "accessoryIsStateful": false,
+            "slats": {
+                "slatType": "horizontal",
+                "defaultSwingMode": "disabled",
+                "defaultTiltAngle": 0,
+                "transitionDuration": 3
+            }
+        }
+    ],
+    "platform": "VirtualAccessoriesForHomebridge"
+}
+```
+
 ### Speaker
 
 ```json
@@ -635,13 +660,19 @@ These are example configurations of the virtual accessories and provided for ref
             "accessoryIsStateful": false,
             "windowCovering": {
                 "defaultState": "closed",
-                "transitionDuration": 3
+                "transitionDuration": 3,
+                "hasTilt": true,
+                "tiltType": "horizontal",
+                "defaultTiltAngle": 0
             }
         }
     ],
     "platform": "VirtualAccessoriesForHomebridge"
 }
 ```
+
+> [!NOTE]
+> Tilt is optional. Omit `hasTilt` (or set it to `false`) for a plain covering with no tilt. When enabled, `tiltType` selects the tilt direction (`horizontal` or `vertical`) and `defaultTiltAngle` sets the initial angle, from -90 to 90 degrees (default 0). If the accessory is stateful, the tilt angle is restored after a restart.
 
 ### Window
 

--- a/README.md
+++ b/README.md
@@ -572,6 +572,8 @@ These are example configurations of the virtual accessories and provided for ref
             "slats": {
                 "slatType": "horizontal",
                 "defaultSwingMode": "disabled",
+                "minTiltAngle": -90,
+                "maxTiltAngle": 90,
                 "defaultTiltAngle": 0,
                 "transitionDuration": 3
             }
@@ -663,6 +665,8 @@ These are example configurations of the virtual accessories and provided for ref
                 "transitionDuration": 3,
                 "hasTilt": true,
                 "tiltType": "horizontal",
+                "minTiltAngle": -90,
+                "maxTiltAngle": 90,
                 "defaultTiltAngle": 0
             }
         }
@@ -672,7 +676,7 @@ These are example configurations of the virtual accessories and provided for ref
 ```
 
 > [!NOTE]
-> Tilt is optional. Omit `hasTilt` (or set it to `false`) for a plain covering with no tilt. When enabled, `tiltType` selects the tilt direction (`horizontal` or `vertical`) and `defaultTiltAngle` sets the initial angle, from -90 to 90 degrees (default 0). If the accessory is stateful, the tilt angle is restored after a restart.
+> Tilt is optional. Omit `hasTilt` (or set it to `false`) for a plain covering with no tilt. When enabled, `tiltType` selects the tilt direction (`horizontal` or `vertical`). `minTiltAngle` and `maxTiltAngle` set the travel range in degrees (defaults -90 and 90); they must be within -90 to 90 and `minTiltAngle` must be less than `maxTiltAngle`. `defaultTiltAngle` sets the initial angle and must fall within that range (default 0). If the accessory is stateful, the tilt angle is restored after a restart.
 
 ### Window
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -762,9 +762,23 @@
                     { "title": "Enabled", "enum": ["enabled"] }
                   ]
                 },
+                "minTiltAngle": {
+                  "title": "Minimum Tilt Angle",
+                  "description": "Minimum tilt angle in degrees, from -90 to 90 (default: -90)",
+                  "type": "integer",
+                  "minimum": -90,
+                  "maximum": 90
+                },
+                "maxTiltAngle": {
+                  "title": "Maximum Tilt Angle",
+                  "description": "Maximum tilt angle in degrees, from -90 to 90 (default: 90)",
+                  "type": "integer",
+                  "minimum": -90,
+                  "maximum": 90
+                },
                 "defaultTiltAngle": {
                   "title": "Default Tilt Angle",
-                  "description": "Initial tilt angle in degrees, from -90 to 90 (default: 0)",
+                  "description": "Initial tilt angle in degrees, within the configured min/max range (default: 0)",
                   "type": "integer",
                   "minimum": -90,
                   "maximum": 90
@@ -943,9 +957,29 @@
                     "functionBody": "return model.devices[arrayIndices].windowCovering && model.devices[arrayIndices].windowCovering.hasTilt === true;"
                   }
                 },
+                "minTiltAngle": {
+                  "title": "Minimum Tilt Angle",
+                  "description": "Minimum tilt angle in degrees, from -90 to 90 (default: -90)",
+                  "type": "integer",
+                  "minimum": -90,
+                  "maximum": 90,
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].windowCovering && model.devices[arrayIndices].windowCovering.hasTilt === true;"
+                  }
+                },
+                "maxTiltAngle": {
+                  "title": "Maximum Tilt Angle",
+                  "description": "Maximum tilt angle in degrees, from -90 to 90 (default: 90)",
+                  "type": "integer",
+                  "minimum": -90,
+                  "maximum": 90,
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].windowCovering && model.devices[arrayIndices].windowCovering.hasTilt === true;"
+                  }
+                },
                 "defaultTiltAngle": {
                   "title": "Default Tilt Angle",
-                  "description": "Initial tilt angle in degrees, from -90 to 90 (default: 0)",
+                  "description": "Initial tilt angle in degrees, within the configured min/max range (default: 0)",
                   "type": "integer",
                   "minimum": -90,
                   "maximum": 90,

--- a/config.schema.json
+++ b/config.schema.json
@@ -146,6 +146,7 @@
                 { "title": "Security System", "enum": ["securitysystem"] },
                 { "title": "Sensor - Measurement", "enum": ["measurement"] },
                 { "title": "Sensor - Triggered", "enum": ["sensor"] },
+                { "title": "Slats", "enum": ["slats"] },
                 { "title": "Speaker", "enum": ["speaker"] },
                 { "title": "Switch", "enum": ["switch"] },
                 { "title": "Television", "enum": ["television"] },
@@ -159,7 +160,7 @@
               "description": "Accessory state survives Homebridge restart",
               "type": "boolean",
               "condition": {
-                "functionBody": "return ['airpurifier', 'door', 'fan', 'garagedoor', 'heatercooler', 'humidifierdehumidifier', 'lightbulb', 'lock', 'securitysystem', 'speaker', 'switch', 'television', 'valve', 'window', 'windowcovering'].includes(model.devices[arrayIndices].accessoryType);"
+                "functionBody": "return ['airpurifier', 'door', 'fan', 'garagedoor', 'heatercooler', 'humidifierdehumidifier', 'lightbulb', 'lock', 'securitysystem', 'slats', 'speaker', 'switch', 'television', 'valve', 'window', 'windowcovering'].includes(model.devices[arrayIndices].accessoryType);"
               }
             },
             "airPurifier": {
@@ -737,6 +738,47 @@
               },
               "condition": {
                 "functionBody": "return model.devices[arrayIndices].accessoryType === 'securitysystem';"
+              }
+            },
+            "slats": {
+              "title": "Slats",
+              "type": "object",
+              "properties": {
+                "slatType": {
+                  "title": "Slat Type *",
+                  "description": "Orientation of the slats",
+                  "type": "string",
+                  "oneOf": [
+                    { "title": "Horizontal", "enum": ["horizontal"] },
+                    { "title": "Vertical", "enum": ["vertical"] }
+                  ]
+                },
+                "defaultSwingMode": {
+                  "title": "Default Swing Mode",
+                  "description": "Whether the slats are swinging by default (default: Disabled)",
+                  "type": "string",
+                  "oneOf": [
+                    { "title": "Disabled", "enum": ["disabled"] },
+                    { "title": "Enabled", "enum": ["enabled"] }
+                  ]
+                },
+                "defaultTiltAngle": {
+                  "title": "Default Tilt Angle",
+                  "description": "Initial tilt angle in degrees, from -90 to 90 (default: 0)",
+                  "type": "integer",
+                  "minimum": -90,
+                  "maximum": 90
+                },
+                "transitionDuration": {
+                  "title": "Transition Duration",
+                  "description": "Tilt transition duration in seconds (default: 3 seconds)",
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 60
+                }
+              },
+              "condition": {
+                "functionBody": "return model.devices[arrayIndices].accessoryType === 'slats';"
               }
             },
             "speaker": {
@@ -1596,6 +1638,21 @@
                 "properties": {
                   "securitySystem": {
                     "required": [ "defaultState" ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "accessoryType": { "const": "slats" }
+                }
+              },
+              "then": {
+                "required": [ "slats" ],
+                "properties": {
+                  "slats": {
+                    "required": [ "slatType" ]
                   }
                 }
               }

--- a/config.schema.json
+++ b/config.schema.json
@@ -867,7 +867,51 @@
             },
             "windowCovering": {
               "title": "Window Covering",
-              "$ref": "#/$defs/doorAndWindowAccessory",
+              "type": "object",
+              "properties": {
+                "defaultState": {
+                  "title": "Default State *",
+                  "type": "string",
+                  "oneOf": [
+                    { "title": "Closed", "enum": ["closed"] },
+                    { "title": "Open", "enum": ["open"] }
+                  ]
+                },
+                "transitionDuration": {
+                  "title": "Transition Duration",
+                  "description": "Open & close transition duration in seconds (default: 3 seconds)",
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 60
+                },
+                "hasTilt": {
+                  "title": "Has Tilt",
+                  "description": "Enable slat tilt angle control (blinds)",
+                  "type": "boolean"
+                },
+                "tiltType": {
+                  "title": "Tilt Type *",
+                  "description": "Direction of the tilt characteristic",
+                  "type": "string",
+                  "oneOf": [
+                    { "title": "Horizontal", "enum": ["horizontal"] },
+                    { "title": "Vertical", "enum": ["vertical"] }
+                  ],
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].windowCovering && model.devices[arrayIndices].windowCovering.hasTilt === true;"
+                  }
+                },
+                "defaultTiltAngle": {
+                  "title": "Default Tilt Angle",
+                  "description": "Initial tilt angle in degrees, from -90 to 90 (default: 0)",
+                  "type": "integer",
+                  "minimum": -90,
+                  "maximum": 90,
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].windowCovering && model.devices[arrayIndices].windowCovering.hasTilt === true;"
+                  }
+                }
+              },
               "condition": {
                 "functionBody": "return model.devices[arrayIndices].accessoryType === 'windowcovering';"
               }

--- a/src/accessories/tilt.ts
+++ b/src/accessories/tilt.ts
@@ -1,0 +1,148 @@
+import type { Characteristic, CharacteristicValue, Service, WithUUID } from 'homebridge';
+
+import { VirtualLogger } from '../utils/virtualLogger.js';
+import { Timer } from '../utils/timer.js';
+
+/**
+ * Tilt - Reusable tilt angle behaviour
+ *
+ * Drives a Current/Target tilt angle characteristic pair with a proportional transition.
+ * Composed by any accessory that exposes a tilt (Window Covering, Slats).
+ */
+export class Tilt {
+
+  // Tilt angle range in degrees: -90 (fully one way) to 90 (fully the other way)
+  static readonly ANGLE_MIN: number = -90;
+  static readonly ANGLE_MAX: number = 90;
+  static readonly ANGLE_RANGE: number = Tilt.ANGLE_MAX - Tilt.ANGLE_MIN;   // 180
+
+  private static readonly MIN_TIMEOUT_SECS: number = 1;
+  private static readonly DEFAULT_TIMEOUT_SECS: number = 3;
+
+  private readonly service: Service;
+  private readonly currentTiltCharacteristic: WithUUID<new () => Characteristic>;
+  private readonly targetTiltCharacteristic: WithUUID<new () => Characteristic>;
+  private readonly log: VirtualLogger;
+  private readonly accessoryName: string;
+  private readonly transitionDuration?: number;
+
+  // Invoked when a transition completes so the owning accessory can persist its state
+  private readonly onTransitionComplete: () => void;
+
+  private transitionTimer: Timer;
+  private transitionSteps: number = 0;
+
+  private states = {
+    CurrentTiltAngle: 0,   // degrees
+    TargetTiltAngle: 0,    // degrees
+  };
+
+  constructor(
+    service: Service,
+    currentTiltCharacteristic: WithUUID<new () => Characteristic>,
+    targetTiltCharacteristic: WithUUID<new () => Characteristic>,
+    log: VirtualLogger,
+    accessoryName: string,
+    initialTiltAngle: number,
+    transitionDuration: number | undefined,
+    onTransitionComplete: () => void,
+  ) {
+    this.service = service;
+    this.currentTiltCharacteristic = currentTiltCharacteristic;
+    this.targetTiltCharacteristic = targetTiltCharacteristic;
+    this.log = log;
+    this.accessoryName = accessoryName;
+    this.transitionDuration = transitionDuration;
+    this.onTransitionComplete = onTransitionComplete;
+
+    this.states.CurrentTiltAngle = initialTiltAngle;
+    this.states.TargetTiltAngle = initialTiltAngle;
+
+    const timerIsResettable: boolean = true;
+    this.transitionTimer = new Timer(
+      this.accessoryName,
+      this.log,
+      timerIsResettable,
+      // No default timer duration
+    );
+
+    // Update the initial tilt state of the accessory
+    this.log.debug(`[${this.accessoryName}] Setting Current Tilt Angle: ${this.states.CurrentTiltAngle}º`);
+    this.service.updateCharacteristic(this.currentTiltCharacteristic, (this.states.CurrentTiltAngle));
+    this.service.updateCharacteristic(this.targetTiltCharacteristic, (this.states.TargetTiltAngle));
+
+    // register handlers
+
+    this.service.getCharacteristic(this.currentTiltCharacteristic)
+      .onGet(this.getCurrentTiltAngle.bind(this));
+
+    this.service.getCharacteristic(this.targetTiltCharacteristic)
+      .onSet(this.setTargetTiltAngle.bind(this))
+      .onGet(this.getTargetTiltAngle.bind(this));
+  }
+
+  // Handlers
+
+  async getCurrentTiltAngle(): Promise<CharacteristicValue> {
+    // If timer is running, then the tilt is moving, so calculate the interim angle
+    if (this.transitionTimer.isTimerRunning()) {
+      const runtimeMillis: number = this.transitionTimer.getRuntime() * 1000;
+      const remainingSteps: number = Math.ceil(this.transitionTimer.getRemainingDurationMillis() / runtimeMillis * this.transitionSteps);
+      this.states.CurrentTiltAngle = this.states.TargetTiltAngle - remainingSteps;
+    }
+    const currentTiltAngle = this.states.CurrentTiltAngle;
+
+    this.log.debug(`[${this.accessoryName}] Getting Current Tilt Angle: ${currentTiltAngle}º`);
+
+    return currentTiltAngle;
+  }
+
+  async setTargetTiltAngle(value: CharacteristicValue) {
+    this.states.TargetTiltAngle = value as number;
+
+    this.log.info(`[${this.accessoryName}] Setting Target Tilt Angle: ${this.states.TargetTiltAngle}º`);
+
+    const transitionDelay: number = (this.transitionDuration ? this.transitionDuration : Tilt.DEFAULT_TIMEOUT_SECS);
+
+    this.transitionSteps = this.states.TargetTiltAngle - this.states.CurrentTiltAngle;
+    this.log.debug(`[${this.accessoryName}] Tilt Transition Steps: ${this.transitionSteps}`);
+    const proportionalTransitionDelay: number = Math.max(
+      // Round up to the nearest second
+      Math.ceil(transitionDelay / Tilt.ANGLE_RANGE * Math.abs(this.transitionSteps)),
+      Tilt.MIN_TIMEOUT_SECS);
+    this.log.debug(`[${this.accessoryName}] Tilt Proportional Delay: ${proportionalTransitionDelay}/(${transitionDelay})`);
+
+    const updateIntervalMillis = 100;
+
+    // Stop tilt transition timer, if running
+    this.transitionTimer.stop();
+
+    this.transitionTimer.start(
+      () => {
+        this.states.CurrentTiltAngle = this.states.TargetTiltAngle;
+        this.service.setCharacteristic(this.currentTiltCharacteristic, (this.states.CurrentTiltAngle));
+
+        this.transitionSteps = 0;
+
+        this.onTransitionComplete();
+
+        this.log.info(`[${this.accessoryName}] Setting Current Tilt Angle: ${this.states.CurrentTiltAngle}º`);
+      },
+      proportionalTransitionDelay,
+      updateIntervalMillis,
+    );
+  }
+
+  async getTargetTiltAngle(): Promise<CharacteristicValue> {
+    const targetTiltAngle = this.states.TargetTiltAngle;
+
+    this.log.debug(`[${this.accessoryName}] Getting Target Tilt Angle: ${targetTiltAngle}º`);
+
+    return targetTiltAngle;
+  }
+
+  // The current tilt angle, exposed for state persistence by the owning accessory
+  getTiltAngle(): number {
+    return this.states.CurrentTiltAngle;
+  }
+}

--- a/src/accessories/tilt.ts
+++ b/src/accessories/tilt.ts
@@ -11,10 +11,9 @@ import { Timer } from '../utils/timer.js';
  */
 export class Tilt {
 
-  // Tilt angle range in degrees: -90 (fully one way) to 90 (fully the other way)
+  // HomeKit tilt angle hard limits in degrees: -90 (fully one way) to 90 (fully the other way)
   static readonly ANGLE_MIN: number = -90;
   static readonly ANGLE_MAX: number = 90;
-  static readonly ANGLE_RANGE: number = Tilt.ANGLE_MAX - Tilt.ANGLE_MIN;   // 180
 
   private static readonly MIN_TIMEOUT_SECS: number = 1;
   private static readonly DEFAULT_TIMEOUT_SECS: number = 3;
@@ -24,6 +23,9 @@ export class Tilt {
   private readonly targetTiltCharacteristic: WithUUID<new () => Characteristic>;
   private readonly log: VirtualLogger;
   private readonly accessoryName: string;
+  private readonly minTiltAngle: number;
+  private readonly maxTiltAngle: number;
+  private readonly tiltAngleRange: number;
   private readonly transitionDuration?: number;
 
   // Invoked when a transition completes so the owning accessory can persist its state
@@ -43,6 +45,8 @@ export class Tilt {
     targetTiltCharacteristic: WithUUID<new () => Characteristic>,
     log: VirtualLogger,
     accessoryName: string,
+    minTiltAngle: number,
+    maxTiltAngle: number,
     initialTiltAngle: number,
     transitionDuration: number | undefined,
     onTransitionComplete: () => void,
@@ -52,6 +56,9 @@ export class Tilt {
     this.targetTiltCharacteristic = targetTiltCharacteristic;
     this.log = log;
     this.accessoryName = accessoryName;
+    this.minTiltAngle = minTiltAngle;
+    this.maxTiltAngle = maxTiltAngle;
+    this.tiltAngleRange = this.maxTiltAngle - this.minTiltAngle;
     this.transitionDuration = transitionDuration;
     this.onTransitionComplete = onTransitionComplete;
 
@@ -65,6 +72,12 @@ export class Tilt {
       timerIsResettable,
       // No default timer duration
     );
+
+    // Constrain the characteristics to the configured range so the Home app slider matches
+    this.service.getCharacteristic(this.currentTiltCharacteristic)
+      .setProps({ minValue: this.minTiltAngle, maxValue: this.maxTiltAngle });
+    this.service.getCharacteristic(this.targetTiltCharacteristic)
+      .setProps({ minValue: this.minTiltAngle, maxValue: this.maxTiltAngle });
 
     // Update the initial tilt state of the accessory
     this.log.debug(`[${this.accessoryName}] Setting Current Tilt Angle: ${this.states.CurrentTiltAngle}º`);
@@ -108,7 +121,7 @@ export class Tilt {
     this.log.debug(`[${this.accessoryName}] Tilt Transition Steps: ${this.transitionSteps}`);
     const proportionalTransitionDelay: number = Math.max(
       // Round up to the nearest second
-      Math.ceil(transitionDelay / Tilt.ANGLE_RANGE * Math.abs(this.transitionSteps)),
+      Math.ceil(transitionDelay / this.tiltAngleRange * Math.abs(this.transitionSteps)),
       Tilt.MIN_TIMEOUT_SECS);
     this.log.debug(`[${this.accessoryName}] Tilt Proportional Delay: ${proportionalTransitionDelay}/(${transitionDelay})`);
 

--- a/src/accessories/virtualAccessorySlats.ts
+++ b/src/accessories/virtualAccessorySlats.ts
@@ -1,0 +1,141 @@
+import type { CharacteristicValue, PlatformAccessory } from 'homebridge';
+
+import { VirtualAccessoriesPlatform } from '../platform.js';
+import { AccessoryConfiguration } from '../configuration/configurationAccessory.js';
+import { Accessory } from './accessory.js';
+import { Tilt } from './tilt.js';
+
+import { SlatType, SwingMode } from '../configuration/schema.js';
+
+/**
+ * Slats - Accessory implementation
+ */
+export class Slats extends Accessory {
+
+  static readonly ACCESSORY_TYPE_NAME: string = 'Slats';
+
+  private readonly swingModeStorageKey: string = 'SwingMode';
+  private readonly tiltStateStorageKey: string = 'TiltAngle';
+
+  private tilt!: Tilt;
+
+  private states = {
+    SwingMode: 0,   // Characteristic.SwingMode
+  };
+
+  constructor(
+    platform: VirtualAccessoriesPlatform,
+    accessory: PlatformAccessory,
+    accessoryConfiguration: AccessoryConfiguration,
+  ) {
+    super(platform, accessory, accessoryConfiguration);
+
+    // The slat orientation is a static property of the accessory, set once from config
+    const slatType: number = (this.accessoryConfiguration.slats.slatType === SlatType.Vertical) ?
+      this.platform.Characteristic.SlatType.VERTICAL :
+      this.platform.Characteristic.SlatType.HORIZONTAL;
+
+    this.states.SwingMode = (this.accessoryConfiguration.slats.defaultSwingMode === SwingMode.Enabled) ?
+      this.platform.Characteristic.SwingMode.SWING_ENABLED :
+      this.platform.Characteristic.SwingMode.SWING_DISABLED;
+
+    let initialTiltAngle: number = this.accessoryConfiguration.slats.defaultTiltAngle ?? 0;
+
+    // If the accessory is stateful retrieve stored state
+    if (this.accessoryConfiguration.accessoryIsStateful) {
+      const accessoryState = this.loadAccessoryState(this.storagePath);
+
+      const cachedSwingMode: number = accessoryState[this.swingModeStorageKey] as number;
+      if (cachedSwingMode !== undefined) {
+        this.states.SwingMode = cachedSwingMode;
+      }
+
+      const cachedTiltAngle: number = accessoryState[this.tiltStateStorageKey] as number;
+      if (cachedTiltAngle !== undefined) {
+        initialTiltAngle = cachedTiltAngle;
+      }
+    }
+
+    this.service = this.accessory.getService(this.platform.Service.Slats) || this.accessory.addService(this.platform.Service.Slats);
+
+    this.service.setCharacteristic(this.platform.Characteristic.Name, this.accessoryConfiguration.accessoryName);
+    this.service.setCharacteristic(this.platform.Characteristic.SlatType, slatType);
+
+    // Update the initial state of the accessory
+    this.service.updateCharacteristic(this.platform.Characteristic.SwingMode, (this.states.SwingMode));
+    this.service.updateCharacteristic(this.platform.Characteristic.CurrentSlatState, (this.currentSlatState()));
+
+    // register handlers
+
+    this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+      .onSet(this.setSwingMode.bind(this))
+      .onGet(this.getSwingMode.bind(this));
+
+    this.service.getCharacteristic(this.platform.Characteristic.CurrentSlatState)
+      .onGet(this.getCurrentSlatState.bind(this));
+
+    // Tilt is always available on a slat
+    this.tilt = new Tilt(
+      this.service,
+      this.platform.Characteristic.CurrentTiltAngle,
+      this.platform.Characteristic.TargetTiltAngle,
+      this.log,
+      this.accessoryConfiguration.accessoryName,
+      initialTiltAngle,
+      this.accessoryConfiguration.slats.transitionDuration,
+      this.storeState.bind(this),
+    );
+  }
+
+  // Handlers
+
+  async setSwingMode(value: CharacteristicValue) {
+    this.states.SwingMode = value as number;
+
+    this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Swing Mode: ${this.getSwingModeName(this.states.SwingMode)}`);
+
+    // Slats swing while swing mode is enabled, otherwise they are fixed
+    this.service!.setCharacteristic(this.platform.Characteristic.CurrentSlatState, (this.currentSlatState()));
+
+    this.storeState();
+  }
+
+  async getSwingMode(): Promise<CharacteristicValue> {
+    const swingMode = this.states.SwingMode;
+
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Getting Swing Mode: ${this.getSwingModeName(swingMode)}`);
+
+    return swingMode;
+  }
+
+  async getCurrentSlatState(): Promise<CharacteristicValue> {
+    const currentSlatState = this.currentSlatState();
+
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Getting Current Slat State: ${currentSlatState}`);
+
+    return currentSlatState;
+  }
+
+  // Derive the slat state from the swing mode: swinging when enabled, fixed when disabled
+  private currentSlatState(): number {
+    return (this.states.SwingMode === this.platform.Characteristic.SwingMode.SWING_ENABLED) ?
+      this.platform.Characteristic.CurrentSlatState.SWINGING :
+      this.platform.Characteristic.CurrentSlatState.FIXED;
+  }
+
+  private getSwingModeName(swingMode: number): string {
+    return (swingMode === this.platform.Characteristic.SwingMode.SWING_ENABLED) ? 'ENABLED' : 'DISABLED';
+  }
+
+  protected getJsonState(): string {
+    const json = JSON.stringify({
+      [this.swingModeStorageKey]: this.states.SwingMode,
+      [this.tiltStateStorageKey]: this.tilt.getTiltAngle(),
+    });
+    return json;
+  }
+
+  protected getAccessoryTypeName(): string {
+    return Slats.ACCESSORY_TYPE_NAME;
+  }
+}

--- a/src/accessories/virtualAccessorySlats.ts
+++ b/src/accessories/virtualAccessorySlats.ts
@@ -39,6 +39,9 @@ export class Slats extends Accessory {
       this.platform.Characteristic.SwingMode.SWING_ENABLED :
       this.platform.Characteristic.SwingMode.SWING_DISABLED;
 
+    const minTiltAngle: number = this.accessoryConfiguration.slats.minTiltAngle ?? Tilt.ANGLE_MIN;
+    const maxTiltAngle: number = this.accessoryConfiguration.slats.maxTiltAngle ?? Tilt.ANGLE_MAX;
+
     let initialTiltAngle: number = this.accessoryConfiguration.slats.defaultTiltAngle ?? 0;
 
     // If the accessory is stateful retrieve stored state
@@ -81,6 +84,8 @@ export class Slats extends Accessory {
       this.platform.Characteristic.TargetTiltAngle,
       this.log,
       this.accessoryConfiguration.accessoryName,
+      minTiltAngle,
+      maxTiltAngle,
       initialTiltAngle,
       this.accessoryConfiguration.slats.transitionDuration,
       this.storeState.bind(this),

--- a/src/accessories/virtualAccessoryWindowCovering.ts
+++ b/src/accessories/virtualAccessoryWindowCovering.ts
@@ -47,6 +47,9 @@ export class WindowCovering extends OpeningAccessory {
       targetTiltCharacteristic = this.platform.Characteristic.TargetHorizontalTiltAngle;
     }
 
+    const minTiltAngle: number = this.accessoryConfiguration.windowCovering.minTiltAngle ?? Tilt.ANGLE_MIN;
+    const maxTiltAngle: number = this.accessoryConfiguration.windowCovering.maxTiltAngle ?? Tilt.ANGLE_MAX;
+
     let initialTiltAngle: number = this.accessoryConfiguration.windowCovering.defaultTiltAngle ?? 0;
 
     // If the accessory is stateful retrieve stored tilt state
@@ -65,6 +68,8 @@ export class WindowCovering extends OpeningAccessory {
       targetTiltCharacteristic,
       this.log,
       this.accessoryConfiguration.accessoryName,
+      minTiltAngle,
+      maxTiltAngle,
       initialTiltAngle,
       this.accessoryConfiguration.windowCovering.transitionDuration,
       this.storeState.bind(this),

--- a/src/accessories/virtualAccessoryWindowCovering.ts
+++ b/src/accessories/virtualAccessoryWindowCovering.ts
@@ -1,10 +1,12 @@
-import type { PlatformAccessory, Service, WithUUID } from 'homebridge';
+import type { Characteristic, CharacteristicValue, PlatformAccessory, Service, WithUUID } from 'homebridge';
 
 import { VirtualAccessoriesPlatform } from '../platform.js';
 import { AccessoryConfiguration } from '../configuration/configurationAccessory.js';
 import { OpeningAccessory } from './openingAccessory.js';
 
 import { OpenableAccessoryConfiguration } from '../configuration/configurationOpenableAccesory.js';
+import { TiltType } from '../configuration/schema.js';
+import { Timer } from '../utils/timer.js';
 
 /**
  * WindowCovering - Accessory implementation
@@ -13,12 +15,150 @@ export class WindowCovering extends OpeningAccessory {
 
   static readonly ACCESSORY_TYPE_NAME: string = 'Window Covering';
 
+  // Tilt angle range in degrees: -90 (fully one way) to 90 (fully the other way)
+  static readonly TILT_ANGLE_MIN: number = -90;
+  static readonly TILT_ANGLE_MAX: number = 90;
+  static readonly TILT_ANGLE_RANGE: number = WindowCovering.TILT_ANGLE_MAX - WindowCovering.TILT_ANGLE_MIN;   // 180
+
+  private static readonly TILT_MIN_TIMEOUT_SECS: number = 1;
+  private static readonly TILT_DEFAULT_TIMEOUT_SECS: number = 3;
+
+  private readonly tiltStateStorageKey: string = 'TiltAngle';
+
+  private hasTilt: boolean = false;
+  private currentTiltCharacteristic!: WithUUID<new () => Characteristic>;
+  private targetTiltCharacteristic!: WithUUID<new () => Characteristic>;
+
+  private tiltTransitionTimer!: Timer;
+  private tiltTransitionSteps: number = 0;
+
+  private tiltStates = {
+    CurrentTiltAngle: 0,   // degrees
+    TargetTiltAngle: 0,    // degrees
+  };
+
   constructor(
     platform: VirtualAccessoriesPlatform,
     accessory: PlatformAccessory,
     accessoryConfiguration: AccessoryConfiguration,
   ) {
     super(platform, accessory, accessoryConfiguration);
+
+    // Tilt is an optional, configurable feature of the window covering
+    this.hasTilt = this.accessoryConfiguration.windowCovering.hasTilt;
+
+    if (this.hasTilt) {
+      this.configureTilt();
+    }
+  }
+
+  private configureTilt(): void {
+    // Select horizontal or vertical tilt characteristics based on config
+    if (this.accessoryConfiguration.windowCovering.tiltType === TiltType.Vertical) {
+      this.currentTiltCharacteristic = this.platform.Characteristic.CurrentVerticalTiltAngle;
+      this.targetTiltCharacteristic = this.platform.Characteristic.TargetVerticalTiltAngle;
+    } else {
+      this.currentTiltCharacteristic = this.platform.Characteristic.CurrentHorizontalTiltAngle;
+      this.targetTiltCharacteristic = this.platform.Characteristic.TargetHorizontalTiltAngle;
+    }
+
+    const defaultTiltAngle: number = this.accessoryConfiguration.windowCovering.defaultTiltAngle ?? 0;
+    this.tiltStates.CurrentTiltAngle = defaultTiltAngle;
+
+    // If the accessory is stateful retrieve stored tilt state
+    if (this.accessoryConfiguration.accessoryIsStateful) {
+      const accessoryState = this.loadAccessoryState(this.storagePath);
+      const cachedTiltAngle: number = accessoryState[this.tiltStateStorageKey] as number;
+
+      if (cachedTiltAngle !== undefined) {
+        this.tiltStates.CurrentTiltAngle = cachedTiltAngle;
+      }
+    }
+
+    this.tiltStates.TargetTiltAngle = this.tiltStates.CurrentTiltAngle;
+
+    const timerIsResettable: boolean = true;
+    this.tiltTransitionTimer = new Timer(
+      this.accessoryConfiguration.accessoryName,
+      this.log,
+      timerIsResettable,
+      // No default timer duration
+    );
+
+    // Update the initial tilt state of the accessory
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Setting Window Covering Current Tilt Angle: ${this.tiltStates.CurrentTiltAngle}º`);
+    this.service!.updateCharacteristic(this.currentTiltCharacteristic, (this.tiltStates.CurrentTiltAngle));
+    this.service!.updateCharacteristic(this.targetTiltCharacteristic, (this.tiltStates.TargetTiltAngle));
+
+    // register handlers
+
+    this.service!.getCharacteristic(this.currentTiltCharacteristic)
+      .onGet(this.getCurrentTiltAngle.bind(this));
+
+    this.service!.getCharacteristic(this.targetTiltCharacteristic)
+      .onSet(this.setTargetTiltAngle.bind(this))
+      .onGet(this.getTargetTiltAngle.bind(this));
+  }
+
+  // Tilt handlers
+
+  async getCurrentTiltAngle(): Promise<CharacteristicValue> {
+    // If timer is running, then the tilt is moving, so calculate the interim angle
+    if (this.tiltTransitionTimer.isTimerRunning()) {
+      const runtimeMillis: number = this.tiltTransitionTimer.getRuntime() * 1000;
+      const remainingSteps: number = Math.ceil(this.tiltTransitionTimer.getRemainingDurationMillis() / runtimeMillis * this.tiltTransitionSteps);
+      this.tiltStates.CurrentTiltAngle = this.tiltStates.TargetTiltAngle - remainingSteps;
+    }
+    const currentTiltAngle = this.tiltStates.CurrentTiltAngle;
+
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Getting Current Tilt Angle: ${currentTiltAngle}º`);
+
+    return currentTiltAngle;
+  }
+
+  async setTargetTiltAngle(value: CharacteristicValue) {
+    this.tiltStates.TargetTiltAngle = value as number;
+
+    this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Target Tilt Angle: ${this.tiltStates.TargetTiltAngle}º`);
+
+    const transitionDuration = this.accessoryConfiguration.windowCovering.transitionDuration;
+    const transitionDelay: number = (transitionDuration ? transitionDuration : WindowCovering.TILT_DEFAULT_TIMEOUT_SECS);
+
+    this.tiltTransitionSteps = this.tiltStates.TargetTiltAngle - this.tiltStates.CurrentTiltAngle;
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Tilt Transition Steps: ${this.tiltTransitionSteps}`);
+    const proportionalTransitionDelay: number = Math.max(
+      // Round up to the nearest second
+      Math.ceil(transitionDelay / WindowCovering.TILT_ANGLE_RANGE * Math.abs(this.tiltTransitionSteps)),
+      WindowCovering.TILT_MIN_TIMEOUT_SECS);
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Tilt Proportional Delay: ${proportionalTransitionDelay}/(${transitionDelay})`);
+
+    const updateIntervalMillis = 100;
+
+    // Stop tilt transition timer, if running
+    this.tiltTransitionTimer.stop();
+
+    this.tiltTransitionTimer.start(
+      () => {
+        this.tiltStates.CurrentTiltAngle = this.tiltStates.TargetTiltAngle;
+        this.service!.setCharacteristic(this.currentTiltCharacteristic, (this.tiltStates.CurrentTiltAngle));
+
+        this.tiltTransitionSteps = 0;
+
+        this.storeState();
+
+        this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Current Tilt Angle: ${this.tiltStates.CurrentTiltAngle}º`);
+      },
+      proportionalTransitionDelay,
+      updateIntervalMillis,
+    );
+  }
+
+  async getTargetTiltAngle(): Promise<CharacteristicValue> {
+    const targetTiltAngle = this.tiltStates.TargetTiltAngle;
+
+    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Getting Target Tilt Angle: ${targetTiltAngle}º`);
+
+    return targetTiltAngle;
   }
 
   protected getOpeningAccessoryConfiguration(): OpenableAccessoryConfiguration {
@@ -31,5 +171,13 @@ export class WindowCovering extends OpeningAccessory {
 
   protected getAccessoryTypeName(): string {
     return WindowCovering.ACCESSORY_TYPE_NAME;
+  }
+
+  protected getJsonState(): string {
+    const state = JSON.parse(super.getJsonState());
+    if (this.hasTilt) {
+      state[this.tiltStateStorageKey] = this.tiltStates.CurrentTiltAngle;
+    }
+    return JSON.stringify(state);
   }
 }

--- a/src/accessories/virtualAccessoryWindowCovering.ts
+++ b/src/accessories/virtualAccessoryWindowCovering.ts
@@ -1,12 +1,12 @@
-import type { Characteristic, CharacteristicValue, PlatformAccessory, Service, WithUUID } from 'homebridge';
+import type { Characteristic, PlatformAccessory, Service, WithUUID } from 'homebridge';
 
 import { VirtualAccessoriesPlatform } from '../platform.js';
 import { AccessoryConfiguration } from '../configuration/configurationAccessory.js';
 import { OpeningAccessory } from './openingAccessory.js';
+import { Tilt } from './tilt.js';
 
 import { OpenableAccessoryConfiguration } from '../configuration/configurationOpenableAccesory.js';
 import { TiltType } from '../configuration/schema.js';
-import { Timer } from '../utils/timer.js';
 
 /**
  * WindowCovering - Accessory implementation
@@ -15,27 +15,10 @@ export class WindowCovering extends OpeningAccessory {
 
   static readonly ACCESSORY_TYPE_NAME: string = 'Window Covering';
 
-  // Tilt angle range in degrees: -90 (fully one way) to 90 (fully the other way)
-  static readonly TILT_ANGLE_MIN: number = -90;
-  static readonly TILT_ANGLE_MAX: number = 90;
-  static readonly TILT_ANGLE_RANGE: number = WindowCovering.TILT_ANGLE_MAX - WindowCovering.TILT_ANGLE_MIN;   // 180
-
-  private static readonly TILT_MIN_TIMEOUT_SECS: number = 1;
-  private static readonly TILT_DEFAULT_TIMEOUT_SECS: number = 3;
-
   private readonly tiltStateStorageKey: string = 'TiltAngle';
 
   private hasTilt: boolean = false;
-  private currentTiltCharacteristic!: WithUUID<new () => Characteristic>;
-  private targetTiltCharacteristic!: WithUUID<new () => Characteristic>;
-
-  private tiltTransitionTimer!: Timer;
-  private tiltTransitionSteps: number = 0;
-
-  private tiltStates = {
-    CurrentTiltAngle: 0,   // degrees
-    TargetTiltAngle: 0,    // degrees
-  };
+  private tilt?: Tilt;
 
   constructor(
     platform: VirtualAccessoriesPlatform,
@@ -54,16 +37,17 @@ export class WindowCovering extends OpeningAccessory {
 
   private configureTilt(): void {
     // Select horizontal or vertical tilt characteristics based on config
+    let currentTiltCharacteristic: WithUUID<new () => Characteristic>;
+    let targetTiltCharacteristic: WithUUID<new () => Characteristic>;
     if (this.accessoryConfiguration.windowCovering.tiltType === TiltType.Vertical) {
-      this.currentTiltCharacteristic = this.platform.Characteristic.CurrentVerticalTiltAngle;
-      this.targetTiltCharacteristic = this.platform.Characteristic.TargetVerticalTiltAngle;
+      currentTiltCharacteristic = this.platform.Characteristic.CurrentVerticalTiltAngle;
+      targetTiltCharacteristic = this.platform.Characteristic.TargetVerticalTiltAngle;
     } else {
-      this.currentTiltCharacteristic = this.platform.Characteristic.CurrentHorizontalTiltAngle;
-      this.targetTiltCharacteristic = this.platform.Characteristic.TargetHorizontalTiltAngle;
+      currentTiltCharacteristic = this.platform.Characteristic.CurrentHorizontalTiltAngle;
+      targetTiltCharacteristic = this.platform.Characteristic.TargetHorizontalTiltAngle;
     }
 
-    const defaultTiltAngle: number = this.accessoryConfiguration.windowCovering.defaultTiltAngle ?? 0;
-    this.tiltStates.CurrentTiltAngle = defaultTiltAngle;
+    let initialTiltAngle: number = this.accessoryConfiguration.windowCovering.defaultTiltAngle ?? 0;
 
     // If the accessory is stateful retrieve stored tilt state
     if (this.accessoryConfiguration.accessoryIsStateful) {
@@ -71,94 +55,20 @@ export class WindowCovering extends OpeningAccessory {
       const cachedTiltAngle: number = accessoryState[this.tiltStateStorageKey] as number;
 
       if (cachedTiltAngle !== undefined) {
-        this.tiltStates.CurrentTiltAngle = cachedTiltAngle;
+        initialTiltAngle = cachedTiltAngle;
       }
     }
 
-    this.tiltStates.TargetTiltAngle = this.tiltStates.CurrentTiltAngle;
-
-    const timerIsResettable: boolean = true;
-    this.tiltTransitionTimer = new Timer(
-      this.accessoryConfiguration.accessoryName,
+    this.tilt = new Tilt(
+      this.service!,
+      currentTiltCharacteristic,
+      targetTiltCharacteristic,
       this.log,
-      timerIsResettable,
-      // No default timer duration
+      this.accessoryConfiguration.accessoryName,
+      initialTiltAngle,
+      this.accessoryConfiguration.windowCovering.transitionDuration,
+      this.storeState.bind(this),
     );
-
-    // Update the initial tilt state of the accessory
-    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Setting Window Covering Current Tilt Angle: ${this.tiltStates.CurrentTiltAngle}º`);
-    this.service!.updateCharacteristic(this.currentTiltCharacteristic, (this.tiltStates.CurrentTiltAngle));
-    this.service!.updateCharacteristic(this.targetTiltCharacteristic, (this.tiltStates.TargetTiltAngle));
-
-    // register handlers
-
-    this.service!.getCharacteristic(this.currentTiltCharacteristic)
-      .onGet(this.getCurrentTiltAngle.bind(this));
-
-    this.service!.getCharacteristic(this.targetTiltCharacteristic)
-      .onSet(this.setTargetTiltAngle.bind(this))
-      .onGet(this.getTargetTiltAngle.bind(this));
-  }
-
-  // Tilt handlers
-
-  async getCurrentTiltAngle(): Promise<CharacteristicValue> {
-    // If timer is running, then the tilt is moving, so calculate the interim angle
-    if (this.tiltTransitionTimer.isTimerRunning()) {
-      const runtimeMillis: number = this.tiltTransitionTimer.getRuntime() * 1000;
-      const remainingSteps: number = Math.ceil(this.tiltTransitionTimer.getRemainingDurationMillis() / runtimeMillis * this.tiltTransitionSteps);
-      this.tiltStates.CurrentTiltAngle = this.tiltStates.TargetTiltAngle - remainingSteps;
-    }
-    const currentTiltAngle = this.tiltStates.CurrentTiltAngle;
-
-    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Getting Current Tilt Angle: ${currentTiltAngle}º`);
-
-    return currentTiltAngle;
-  }
-
-  async setTargetTiltAngle(value: CharacteristicValue) {
-    this.tiltStates.TargetTiltAngle = value as number;
-
-    this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Target Tilt Angle: ${this.tiltStates.TargetTiltAngle}º`);
-
-    const transitionDuration = this.accessoryConfiguration.windowCovering.transitionDuration;
-    const transitionDelay: number = (transitionDuration ? transitionDuration : WindowCovering.TILT_DEFAULT_TIMEOUT_SECS);
-
-    this.tiltTransitionSteps = this.tiltStates.TargetTiltAngle - this.tiltStates.CurrentTiltAngle;
-    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Tilt Transition Steps: ${this.tiltTransitionSteps}`);
-    const proportionalTransitionDelay: number = Math.max(
-      // Round up to the nearest second
-      Math.ceil(transitionDelay / WindowCovering.TILT_ANGLE_RANGE * Math.abs(this.tiltTransitionSteps)),
-      WindowCovering.TILT_MIN_TIMEOUT_SECS);
-    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Tilt Proportional Delay: ${proportionalTransitionDelay}/(${transitionDelay})`);
-
-    const updateIntervalMillis = 100;
-
-    // Stop tilt transition timer, if running
-    this.tiltTransitionTimer.stop();
-
-    this.tiltTransitionTimer.start(
-      () => {
-        this.tiltStates.CurrentTiltAngle = this.tiltStates.TargetTiltAngle;
-        this.service!.setCharacteristic(this.currentTiltCharacteristic, (this.tiltStates.CurrentTiltAngle));
-
-        this.tiltTransitionSteps = 0;
-
-        this.storeState();
-
-        this.log.info(`[${this.accessoryConfiguration.accessoryName}] Setting Current Tilt Angle: ${this.tiltStates.CurrentTiltAngle}º`);
-      },
-      proportionalTransitionDelay,
-      updateIntervalMillis,
-    );
-  }
-
-  async getTargetTiltAngle(): Promise<CharacteristicValue> {
-    const targetTiltAngle = this.tiltStates.TargetTiltAngle;
-
-    this.log.debug(`[${this.accessoryConfiguration.accessoryName}] Getting Target Tilt Angle: ${targetTiltAngle}º`);
-
-    return targetTiltAngle;
   }
 
   protected getOpeningAccessoryConfiguration(): OpenableAccessoryConfiguration {
@@ -176,7 +86,7 @@ export class WindowCovering extends OpeningAccessory {
   protected getJsonState(): string {
     const state = JSON.parse(super.getJsonState());
     if (this.hasTilt) {
-      state[this.tiltStateStorageKey] = this.tiltStates.CurrentTiltAngle;
+      state[this.tiltStateStorageKey] = this.tilt!.getTiltAngle();
     }
     return JSON.stringify(state);
   }

--- a/src/accessoryFactory.ts
+++ b/src/accessoryFactory.ts
@@ -16,6 +16,7 @@ import { Lightbulb } from './accessories/virtualAccessoryLightbulb.js';
 import { Lock } from './accessories/virtualAccessoryLock.js';
 import { Microphone } from './accessories/virtualAccessoryMicrophone.js';
 import { SecuritySystem } from './accessories/virtualAccessorySecuritySystem.js';
+import { Slats } from './accessories/virtualAccessorySlats.js';
 import { SmartSpeaker } from './accessories/virtualAccessorySmartSpeaker.js';
 //import { Speaker } from './accessories/virtualAccessorySpeaker.js';
 import { Switch } from './accessories/virtualAccessorySwitch.js';
@@ -110,6 +111,9 @@ export abstract class AccessoryFactory {
       break;
     case AccessoryType.SecuritySystem:
       virtualAccessory = new SecuritySystem(platform, accessory, accessoryConfiguration);
+      break;
+    case AccessoryType.Slats:
+      virtualAccessory = new Slats(platform, accessory, accessoryConfiguration);
       break;
     case AccessoryType.Speaker:
       virtualAccessory = new SmartSpeaker(platform, accessory, accessoryConfiguration);

--- a/src/configuration/accessories/configurationSlats.ts
+++ b/src/configuration/accessories/configurationSlats.ts
@@ -2,6 +2,7 @@
 
 import { Validatable } from '../validatable.js';
 import { SlatType, SwingMode } from '../schema.js';
+import { Tilt } from '../../accessories/tilt.js';
 
 import { Utils } from '../../utils/utils.js';
 
@@ -11,6 +12,8 @@ import { Utils } from '../../utils/utils.js';
 export class SlatsConfiguration implements Validatable {
   slatType!: string;
   defaultSwingMode!: string;
+  minTiltAngle!: number;
+  maxTiltAngle!: number;
   defaultTiltAngle!: number;
   transitionDuration!: number;
 
@@ -19,6 +22,10 @@ export class SlatsConfiguration implements Validatable {
   readonly fieldNames = Utils.proxiedPropertiesOf(this);
 
   isValid(prefix: string): [boolean, string[]] {
+    // Fall back to the HomeKit hard limits when the range is not configured
+    const minTiltAngle: number = this.minTiltAngle ?? Tilt.ANGLE_MIN;
+    const maxTiltAngle: number = this.maxTiltAngle ?? Tilt.ANGLE_MAX;
+
     const isValidSlatType: boolean = (
       Utils.required(this.slatType) &&
       SlatType.Types.includes(this.slatType)
@@ -30,9 +37,25 @@ export class SlatsConfiguration implements Validatable {
         true
     );
 
+    const isValidMinTiltAngle: boolean = (
+      this.minTiltAngle !== undefined ?
+        Utils.isValidTiltAngle(this.minTiltAngle) :
+        true
+    );
+
+    const isValidMaxTiltAngle: boolean = (
+      this.maxTiltAngle !== undefined ?
+        Utils.isValidTiltAngle(this.maxTiltAngle) :
+        true
+    );
+
+    const isValidTiltRange: boolean = (
+      minTiltAngle < maxTiltAngle
+    );
+
     const isValidDefaultTiltAngle: boolean = (
       this.defaultTiltAngle !== undefined ?
-        Utils.isValidTiltAngle(this.defaultTiltAngle) :
+        (this.defaultTiltAngle >= minTiltAngle && this.defaultTiltAngle <= maxTiltAngle) :
         true
     );
 
@@ -45,12 +68,18 @@ export class SlatsConfiguration implements Validatable {
     // Store fields failing validation
     if (!isValidSlatType) this.errorFields.push(prefix + '.' + this.fieldNames.slatType);
     if (!isValidDefaultSwingMode) this.errorFields.push(prefix + '.' + this.fieldNames.defaultSwingMode);
+    if (!isValidMinTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.minTiltAngle);
+    if (!isValidMaxTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.maxTiltAngle);
+    if (!isValidTiltRange) this.errorFields.push(prefix + '.' + this.fieldNames.minTiltAngle + ' < ' + prefix + '.' + this.fieldNames.maxTiltAngle);
     if (!isValidDefaultTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.defaultTiltAngle);
     if (!isValidTransitionDuration) this.errorFields.push(prefix + '.' + this.fieldNames.transitionDuration);
 
     return [
       (isValidSlatType &&
         isValidDefaultSwingMode &&
+        isValidMinTiltAngle &&
+        isValidMaxTiltAngle &&
+        isValidTiltRange &&
         isValidDefaultTiltAngle &&
         isValidTransitionDuration),
       this.errorFields,

--- a/src/configuration/accessories/configurationSlats.ts
+++ b/src/configuration/accessories/configurationSlats.ts
@@ -1,0 +1,59 @@
+/* eslint-disable curly */
+
+import { Validatable } from '../validatable.js';
+import { SlatType, SwingMode } from '../schema.js';
+
+import { Utils } from '../../utils/utils.js';
+
+/**
+ *
+ */
+export class SlatsConfiguration implements Validatable {
+  slatType!: string;
+  defaultSwingMode!: string;
+  defaultTiltAngle!: number;
+  transitionDuration!: number;
+
+  private errorFields: string[] = [];
+
+  readonly fieldNames = Utils.proxiedPropertiesOf(this);
+
+  isValid(prefix: string): [boolean, string[]] {
+    const isValidSlatType: boolean = (
+      Utils.required(this.slatType) &&
+      SlatType.Types.includes(this.slatType)
+    );
+
+    const isValidDefaultSwingMode: boolean = (
+      this.defaultSwingMode !== undefined ?
+        SwingMode.Modes.includes(this.defaultSwingMode) :
+        true
+    );
+
+    const isValidDefaultTiltAngle: boolean = (
+      this.defaultTiltAngle !== undefined ?
+        Utils.isValidTiltAngle(this.defaultTiltAngle) :
+        true
+    );
+
+    const isValidTransitionDuration: boolean = (
+      this.transitionDuration !== undefined ?
+        Utils.isValidTransition(this.transitionDuration) :
+        true
+    );
+
+    // Store fields failing validation
+    if (!isValidSlatType) this.errorFields.push(prefix + '.' + this.fieldNames.slatType);
+    if (!isValidDefaultSwingMode) this.errorFields.push(prefix + '.' + this.fieldNames.defaultSwingMode);
+    if (!isValidDefaultTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.defaultTiltAngle);
+    if (!isValidTransitionDuration) this.errorFields.push(prefix + '.' + this.fieldNames.transitionDuration);
+
+    return [
+      (isValidSlatType &&
+        isValidDefaultSwingMode &&
+        isValidDefaultTiltAngle &&
+        isValidTransitionDuration),
+      this.errorFields,
+    ];
+  }
+}

--- a/src/configuration/accessories/configurationWindowCovering.ts
+++ b/src/configuration/accessories/configurationWindowCovering.ts
@@ -2,6 +2,7 @@
 
 import { OpenableAccessoryConfiguration } from '../configurationOpenableAccesory.js';
 import { OpenableState, TiltType } from '../schema.js';
+import { Tilt } from '../../accessories/tilt.js';
 
 import { Utils } from '../../utils/utils.js';
 
@@ -15,6 +16,8 @@ export class WindowCoveringConfiguration extends OpenableAccessoryConfiguration 
   // Tilt
   hasTilt: boolean = false;
   tiltType!: string;
+  minTiltAngle!: number;
+  maxTiltAngle!: number;
   defaultTiltAngle!: number;
 
   private errorFields: string[] = [];
@@ -22,6 +25,10 @@ export class WindowCoveringConfiguration extends OpenableAccessoryConfiguration 
   readonly fieldNames = Utils.proxiedPropertiesOf(this);
 
   isValid(prefix: string): [boolean, string[]] {
+    // Fall back to the HomeKit hard limits when the range is not configured
+    const minTiltAngle: number = this.minTiltAngle ?? Tilt.ANGLE_MIN;
+    const maxTiltAngle: number = this.maxTiltAngle ?? Tilt.ANGLE_MAX;
+
     const isValidDefaultState: boolean = (
       Utils.required(this.defaultState) &&
       OpenableState.States.includes(this.defaultState)
@@ -39,9 +46,27 @@ export class WindowCoveringConfiguration extends OpenableAccessoryConfiguration 
         true
     );
 
+    const isValidMinTiltAngle: boolean = (
+      this.hasTilt && this.minTiltAngle !== undefined ?
+        Utils.isValidTiltAngle(this.minTiltAngle) :
+        true
+    );
+
+    const isValidMaxTiltAngle: boolean = (
+      this.hasTilt && this.maxTiltAngle !== undefined ?
+        Utils.isValidTiltAngle(this.maxTiltAngle) :
+        true
+    );
+
+    const isValidTiltRange: boolean = (
+      this.hasTilt ?
+        (minTiltAngle < maxTiltAngle) :
+        true
+    );
+
     const isValidDefaultTiltAngle: boolean = (
       this.hasTilt && this.defaultTiltAngle !== undefined ?
-        Utils.isValidTiltAngle(this.defaultTiltAngle) :
+        (this.defaultTiltAngle >= minTiltAngle && this.defaultTiltAngle <= maxTiltAngle) :
         true
     );
 
@@ -49,12 +74,18 @@ export class WindowCoveringConfiguration extends OpenableAccessoryConfiguration 
     if (!isValidDefaultState) this.errorFields.push(prefix + '.' + this.fieldNames.defaultState);
     if (!isValidTransitionDuration) this.errorFields.push(prefix + '.' + this.fieldNames.transitionDuration);
     if (!isValidTiltType) this.errorFields.push(prefix + '.' + this.fieldNames.tiltType);
+    if (!isValidMinTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.minTiltAngle);
+    if (!isValidMaxTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.maxTiltAngle);
+    if (!isValidTiltRange) this.errorFields.push(prefix + '.' + this.fieldNames.minTiltAngle + ' < ' + prefix + '.' + this.fieldNames.maxTiltAngle);
     if (!isValidDefaultTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.defaultTiltAngle);
 
     return [
       (isValidDefaultState &&
         isValidTransitionDuration &&
         isValidTiltType &&
+        isValidMinTiltAngle &&
+        isValidMaxTiltAngle &&
+        isValidTiltRange &&
         isValidDefaultTiltAngle),
       this.errorFields,
     ];

--- a/src/configuration/accessories/configurationWindowCovering.ts
+++ b/src/configuration/accessories/configurationWindowCovering.ts
@@ -1,16 +1,21 @@
 /* eslint-disable curly */
 
 import { OpenableAccessoryConfiguration } from '../configurationOpenableAccesory.js';
-import { OpenableState } from '../schema.js';
+import { OpenableState, TiltType } from '../schema.js';
 
 import { Utils } from '../../utils/utils.js';
 
 /**
- * 
+ *
  */
 export class WindowCoveringConfiguration extends OpenableAccessoryConfiguration {
   // defaultState!: string;
   // transitionDuration!: number;
+
+  // Tilt
+  hasTilt: boolean = false;
+  tiltType!: string;
+  defaultTiltAngle!: number;
 
   private errorFields: string[] = [];
 
@@ -28,13 +33,29 @@ export class WindowCoveringConfiguration extends OpenableAccessoryConfiguration 
         true
     );
 
+    const isValidTiltType: boolean = (
+      this.hasTilt ?
+        (Utils.required(this.tiltType) && TiltType.Types.includes(this.tiltType)) :
+        true
+    );
+
+    const isValidDefaultTiltAngle: boolean = (
+      this.hasTilt && this.defaultTiltAngle !== undefined ?
+        Utils.isValidTiltAngle(this.defaultTiltAngle) :
+        true
+    );
+
     // Store fields failing validation
     if (!isValidDefaultState) this.errorFields.push(prefix + '.' + this.fieldNames.defaultState);
     if (!isValidTransitionDuration) this.errorFields.push(prefix + '.' + this.fieldNames.transitionDuration);
+    if (!isValidTiltType) this.errorFields.push(prefix + '.' + this.fieldNames.tiltType);
+    if (!isValidDefaultTiltAngle) this.errorFields.push(prefix + '.' + this.fieldNames.defaultTiltAngle);
 
     return [
       (isValidDefaultState &&
-        isValidTransitionDuration),
+        isValidTransitionDuration &&
+        isValidTiltType &&
+        isValidDefaultTiltAngle),
       this.errorFields,
     ];
   }

--- a/src/configuration/configurationAccessory.ts
+++ b/src/configuration/configurationAccessory.ts
@@ -17,6 +17,7 @@ import { LightbulbConfiguration } from './accessories/configurationLightbulb.js'
 import { LockConfiguration } from './accessories/configurationLock.js';
 import { MicrophoneConfiguration } from './accessories/configurationMicrophone.js';
 import { SecuritySystemConfiguration } from './accessories/configurationSecuritySystem.js';
+import { SlatsConfiguration } from './accessories/configurationSlats.js';
 import { SpeakerConfiguration } from './accessories/configurationSpeaker.js';
 import { SwitchConfiguration } from './accessories/configurationSwitch.js';
 import { TelevisionConfiguration } from './accessories/configurationTelevision.js';
@@ -111,6 +112,10 @@ export class AccessoryConfiguration {
   // SecuritySystem
   @Type(SecuritySystemConfiguration)
     securitySystem!: SecuritySystemConfiguration;
+
+  // Slats
+  @Type(SlatsConfiguration)
+    slats!: SlatsConfiguration;
 
   // Speaker
   @Type(SpeakerConfiguration)
@@ -263,6 +268,8 @@ export class AccessoryConfiguration {
       return this.isErrorless(this.microphone, this.fieldNames.microphone!);
     case AccessoryType.SecuritySystem:
       return this.isErrorless(this.securitySystem, this.fieldNames.securitySystem!);
+    case AccessoryType.Slats:
+      return this.isErrorless(this.slats, this.fieldNames.slats!);
     case AccessoryType.Speaker:
       this.category = Categories.SPEAKER;
       return this.isErrorless(this.speaker, this.fieldNames.speaker!);

--- a/src/configuration/schema.ts
+++ b/src/configuration/schema.ts
@@ -18,6 +18,7 @@ export class AccessoryType {
   static SecuritySystem: string = 'securitysystem';
   static SensorBinary: string = 'sensor';
   static SensorMeasurement: string = 'measurement';
+  static Slats: string = 'slats';
   static Speaker: string = 'speaker';
   static Switch: string = 'switch';
   static Television: string = 'television';
@@ -123,12 +124,23 @@ export class TiltType {
 /**
  *
  */
-export class TiltAngle {
+export class SlatType {
 
-  // HomeKit units: degrees
+  static Horizontal: string = 'horizontal';
+  static Vertical: string = 'vertical';
 
-  static AngleMin: number = -90;
-  static AngleMax: number = 90;
+  static Types: string[] = [ SlatType.Horizontal, SlatType.Vertical ];
+}
+
+/**
+ *
+ */
+export class SwingMode {
+
+  static Disabled: string = 'disabled';
+  static Enabled: string = 'enabled';
+
+  static Modes: string[] = [ SwingMode.Disabled, SwingMode.Enabled ];
 }
 
 /**

--- a/src/configuration/schema.ts
+++ b/src/configuration/schema.ts
@@ -110,6 +110,28 @@ export class OpenableState {
 }
 
 /**
+ *
+ */
+export class TiltType {
+
+  static Horizontal: string = 'horizontal';
+  static Vertical: string = 'vertical';
+
+  static Types: string[] = [ TiltType.Horizontal, TiltType.Vertical ];
+}
+
+/**
+ *
+ */
+export class TiltAngle {
+
+  // HomeKit units: degrees
+
+  static AngleMin: number = -90;
+  static AngleMax: number = 90;
+}
+
+/**
  * 
  */
 export class TemperatureUnit {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -184,6 +184,10 @@ export class Utils {
     return (value >= 0 && value <= 360);
   }
 
+  static isValidTiltAngle(value: number): boolean {
+    return (value >= -90 && value <= 90);
+  }
+
   static isValidTransition(value: number): boolean {
     return (value >= 0);
   }


### PR DESCRIPTION
Adding support for tilt functionality to the virtual Window Covering type.

Additionally this goes ahead and adds the "Slat" virtual device type, which is just a window covering without open/close.

<img width="300" alt="Screenshot 2026-08-08 at 5 27 07 PM" src="https://github.com/user-attachments/assets/88e0cb7f-0c9c-479b-8160-72670245e680" /><img width="300" alt="Screenshot 2026-08-08 at 5 27 41 PM" src="https://github.com/user-attachments/assets/c079b6d9-be62-472f-a5b2-7664a0524c59" />

<img width="350" alt="Screenshot 2026-08-08 at 5 38 46 PM" src="https://github.com/user-attachments/assets/3b8ed060-0239-4586-a718-ae8ea9d29e5b" />
<img width="350" alt="Screenshot 2026-08-08 at 5 38 54 PM" src="https://github.com/user-attachments/assets/bd67a089-1eb0-48c2-800c-0a6c02fbdd79" />