### PR TITLE
Changes to the Ping Sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1147,10 +1147,10 @@
                 },
                 "interval": {
                   "title": "Interval Between Pings",
-                  "description": "Interval between pings in minutes - low for crical infrastructure, higher for non-critical devices (default: 1 minute)",
+                  "description": "Interval between pings in milliseconds - low for crical infrastructure, higher for non-critical devices (default: 60000ms)",
                   "type": "integer",
-                  "minimum": 1,
-                  "maximum": 15
+                  "minimum": 100,
+                  "maximum": 900000
                 },
                 "isDisabled": {
                   "title": "Disable Trigger",

--- a/src/configuration/triggers/configurationPingTrigger.ts
+++ b/src/configuration/triggers/configurationPingTrigger.ts
@@ -10,7 +10,7 @@ import { Utils } from '../../utils/utils.js';
 export class PingTriggerConfiguration implements Validatable {
   host!: string;
   failureRetryCount!: number;
-  interval: number = 1;
+  interval: number = 60000;
   isDisabled: boolean = false;
 
   private errorFields: string[] = [];
@@ -27,7 +27,7 @@ export class PingTriggerConfiguration implements Validatable {
     );
 
     const isValidInterval: boolean = (
-      this.interval >= 1 && this.interval <= 15
+      this.interval >= 100 && this.interval <= 900000
     );
 
     if (!isValidHost) this.errorFields.push(prefix + '.' + this.fieldNames.host!);

--- a/src/sensors/triggers/triggerPing.ts
+++ b/src/sensors/triggers/triggerPing.ts
@@ -76,8 +76,8 @@ export class PingTrigger extends Trigger {
     }
     this.log.debug(`[${this.accessoryName}] Protocol: ${ping.NetworkProtocol[protocol]}`);
 
-    const intervalBetweenPingsMillis = triggerConfig.interval * 60 * 1000;
-    this.log.info(`[${this.accessoryName}] Setting interval between pings to ${intervalBetweenPingsMillis/1000/60} minute(s)`);
+    const intervalBetweenPingsMillis = triggerConfig.interval;
+    this.log.info(`[${this.accessoryName}] Setting interval between pings to ${intervalBetweenPingsMillis}ms`);
     const pingTimeoutMillis = 10 * 1000;
 
     setInterval(

--- a/src/sensors/triggers/triggerPing.ts
+++ b/src/sensors/triggers/triggerPing.ts
@@ -110,7 +110,7 @@ export class PingTrigger extends Trigger {
     const options = {
       networkProtocol: protocol,
       packetSize: 16,
-      retries: 3,
+      retries: 0,
       sessionId: 1 + Math.floor(Math.random() * 65534),
       timeout: pingTimeoutMillis,
       ttl: 128,

--- a/src/sensors/triggers/triggerPing.ts
+++ b/src/sensors/triggers/triggerPing.ts
@@ -111,7 +111,7 @@ export class PingTrigger extends Trigger {
       networkProtocol: protocol,
       packetSize: 16,
       retries: 3,
-      sessionId: (process.pid % 65535),
+      sessionId: 1 + Math.floor(Math.random() * 65534),
       timeout: pingTimeoutMillis,
       ttl: 128,
     };


### PR DESCRIPTION
I wanted to make a ping contact sensor to trigger when my TV turns on, so I could make an automation in Apple Home to turn on the amplifier. The current implementation of the ping trigger can only trigger every 1 minute (with possible retries), so it would take a while to get sound after the TV turned on.

I have made this PR as a suggestion to change the ping trigger to use milliseconds instead of minutes (a breaking change), so it would be possible for the user to go as low as 100ms.

When I added more ping triggers, I started getting false positives, because `sessionId` was set as the process PID (reused) and not a random ID.

Lastly, I found `retries: 3` confusing, as the user also set `failureRetryCount` in the plugin config. So if a host is down, the number of pings sent would triple. I have suggested, that we remove it and rely solely on the user specified retries in `failureRetryCount`.