### PR TITLE
Fix HomeKey device credential response TLV type

### DIFF
--- a/src/utils/tlv.ts
+++ b/src/utils/tlv.ts
@@ -267,7 +267,7 @@ export class TLVDeviceCredentialResponse {
       responseValue = this.status!.toHexString();
     }
 
-    const responseType: string = TLVUtils.toHexString(TLVUtils.1. READER_KEY_RESPONSE);
+    const responseType: string = TLVUtils.toHexString(TLVUtils.DEVICE_CREDENTIAL_RESPONSE);
     const responseLength = TLVUtils.toHexString(responseValue.length / 2);   // hex values are two characters
 
     return `${responseType}${responseLength}${responseValue}`;


### PR DESCRIPTION
Device Credential Response uses TLV type `05`, while Reader Key Response uses `07`. The existing implementation incorrectly emitted `07`; this change emits the correct Device Credential Response type `05`.