### PR TITLE
Fix ping trigger session ID and retry count

### DIFF
--- a/src/sensors/triggers/triggerPing.ts
+++ b/src/sensors/triggers/triggerPing.ts
@@ -111,7 +111,7 @@ export class PingTrigger extends Trigger {
       networkProtocol: protocol,
       packetSize: 16,
       retries: triggerConfig.failureRetryCount,
-      sessionId: Math.floor(Math.random() * 65535) + 1,
+      sessionId: Math.floor(Math.random() * 65534) + 1,
       timeout: pingTimeoutMillis,
       ttl: 128,
     };

--- a/src/sensors/triggers/triggerPing.ts
+++ b/src/sensors/triggers/triggerPing.ts
@@ -110,8 +110,8 @@ export class PingTrigger extends Trigger {
     const options = {
       networkProtocol: protocol,
       packetSize: 16,
-      retries: 3,
-      sessionId: (process.pid % 65535),
+      retries: triggerConfig.failureRetryCount,
+      sessionId: Math.floor(Math.random() * 65535) + 1,
       timeout: pingTimeoutMillis,
       ttl: 128,
     };


### PR DESCRIPTION
Fixes #910.

- Use the configured failure retry count for net-ping retries.
- Generate a random valid net-ping ICMP session ID in the 1–65534 range.